### PR TITLE
compareCanvases: More info about mismatches

### DIFF
--- a/src/test/common.ts
+++ b/src/test/common.ts
@@ -135,7 +135,13 @@ export function compareCanvases(expected: HTMLCanvasElement | undefined, actual:
 	for (let i = 0; i < length; i++) {
 		if (expectedData.data[i] !== actualData.data[i]) {
 			saveFailure();
-			throw new Error(`Actual canvas different than expected (${name})`);
+			const expectedNumBytes = expectedData.data.length;
+			const actualNumBytes = actualData.data.length;
+			throw new Error(
+				`Actual canvas (${actualNumBytes} bytes) different ` +
+				`than expected (${name}: ${expectedNumBytes} bytes) ` +
+				`at index ${i}: actual ${actualData.data[i]} vs. expected ${expectedData.data[i]}`
+			);
 		}
 	}
 }


### PR DESCRIPTION
to help dig into https://github.com/Agamnentzar/ag-psd/issues/6 a bit more...

Example output:

```
$ npm test
...
  1) PsdReader
       reads PSD file (background):
     Error: Actual canvas (68480 bytes) different than expected (background/thumb.png: 68480 bytes) at index 28: actual 250 vs. expected 249
      at Object.compareCanvases (src/test/common.ts:141:10)
      at /Users/abramowi/dev/git-repos/ag-psd/src/test/psdReader.spec.ts:92:25
      at Array.forEach (<anonymous>)
      at Context.<anonymous> (src/test/psdReader.spec.ts:92:12)

  2) PsdReader
       reads PSD file (blend-mode):
     Error: Actual canvas (68480 bytes) different than expected (blend-mode/thumb.png: 68480 bytes) at index 129: actual 251 vs. expected 253
      at Object.compareCanvases (src/test/common.ts:141:10)
      at /Users/abramowi/dev/git-repos/ag-psd/src/test/psdReader.spec.ts:92:25
      at Array.forEach (<anonymous>)
      at Context.<anonymous> (src/test/psdReader.spec.ts:92:12)

  3) PsdReader
       reads PSD file (cat):
     Error: Actual canvas (2128 bytes) different than expected (cat/thumb.png: 2128 bytes) at index 38: actual 252 vs. expected 250
      at Object.compareCanvases (src/test/common.ts:141:10)
      at /Users/abramowi/dev/git-repos/ag-psd/src/test/psdReader.spec.ts:92:25
      at Array.forEach (<anonymous>)
      at Context.<anonymous> (src/test/psdReader.spec.ts:92:12)

  4) PsdReader
       reads PSD file (groups):
     Error: Actual canvas (68480 bytes) different than expected (groups/thumb.png: 68480 bytes) at index 60: actual 255 vs. expected 254
      at Object.compareCanvases (src/test/common.ts:141:10)
      at /Users/abramowi/dev/git-repos/ag-psd/src/test/psdReader.spec.ts:92:25
      at Array.forEach (<anonymous>)
      at Context.<anonymous> (src/test/psdReader.spec.ts:92:12)

  5) PsdReader
       reads PSD file (lantern):
     Error: Actual canvas (504 bytes) different than expected (lantern/thumb.png: 504 bytes) at index 0: actual 248 vs. expected 249
      at Object.compareCanvases (src/test/common.ts:141:10)
      at /Users/abramowi/dev/git-repos/ag-psd/src/test/psdReader.spec.ts:92:25
      at Array.forEach (<anonymous>)
      at Context.<anonymous> (src/test/psdReader.spec.ts:92:12)

  6) PsdReader
       reads PSD file (layer-mask):
     Error: Actual canvas (102400 bytes) different than expected (layer-mask/thumb.png: 102400 bytes) at index 129: actual 255 vs. expected 254
      at Object.compareCanvases (src/test/common.ts:141:10)
      at /Users/abramowi/dev/git-repos/ag-psd/src/test/psdReader.spec.ts:92:25
      at Array.forEach (<anonymous>)
      at Context.<anonymous> (src/test/psdReader.spec.ts:92:12)

  7) PsdReader
       reads PSD file (layer-offsets-read):
     Error: Actual canvas (67840 bytes) different than expected (layer-offsets-read/thumb.png: 67840 bytes) at index 9862: actual 255 vs. expected 253
      at Object.compareCanvases (src/test/common.ts:141:10)
      at /Users/abramowi/dev/git-repos/ag-psd/src/test/psdReader.spec.ts:92:25
      at Array.forEach (<anonymous>)
      at Context.<anonymous> (src/test/psdReader.spec.ts:92:12)

  8) PsdReader
       reads PSD file (layers):
     Error: Actual canvas (68480 bytes) different than expected (layers/thumb.png: 68480 bytes) at index 61: actual 137 vs. expected 138
      at Object.compareCanvases (src/test/common.ts:141:10)
      at /Users/abramowi/dev/git-repos/ag-psd/src/test/psdReader.spec.ts:92:25
      at Array.forEach (<anonymous>)
      at Context.<anonymous> (src/test/psdReader.spec.ts:92:12)

  9) PsdReader
       reads PSD file (section-2):
     Error: Actual canvas (40000 bytes) different than expected (section-2/thumb.png: 40000 bytes) at index 12400: actual 144 vs. expected 146
      at Object.compareCanvases (src/test/common.ts:141:10)
      at /Users/abramowi/dev/git-repos/ag-psd/src/test/psdReader.spec.ts:92:25
      at Array.forEach (<anonymous>)
      at Context.<anonymous> (src/test/psdReader.spec.ts:92:12)
...
```