### PR TITLE
Use pixelmatch for psdReader tests

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "ag-psd",
-  "version": "5.0.2",
+  "version": "6.1.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -58,8 +58,15 @@
     "@types/node": {
       "version": "10.14.1",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-10.14.1.tgz",
-      "integrity": "sha512-Rymt08vh1GaW4vYB6QP61/5m/CFLGnFZP++bJpWbiNxceNa6RBipDmb413jvtSf/R1gg5a/jQVl2jY4XVRscEA==",
-      "dev": true
+      "integrity": "sha512-Rymt08vh1GaW4vYB6QP61/5m/CFLGnFZP++bJpWbiNxceNa6RBipDmb413jvtSf/R1gg5a/jQVl2jY4XVRscEA=="
+    },
+    "@types/pixelmatch": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@types/pixelmatch/-/pixelmatch-4.0.0.tgz",
+      "integrity": "sha512-pOF+6b0UbePCuPv1BS2k1IEeTk8ae8mhNiHms05s5WM+xV47g8Fb7KQcMn1fkJ9ccbs2IDpgPv+fGmHHvHHnrA==",
+      "requires": {
+        "@types/node": "*"
+      }
     },
     "JSONStream": {
       "version": "1.3.5",
@@ -4880,6 +4887,14 @@
         "pinkie": "^2.0.0"
       }
     },
+    "pixelmatch": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/pixelmatch/-/pixelmatch-4.0.2.tgz",
+      "integrity": "sha1-j0fc7FARtHe2fbA8JDvB8wheiFQ=",
+      "requires": {
+        "pngjs": "^3.0.0"
+      }
+    },
     "plugin-error": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/plugin-error/-/plugin-error-1.0.1.tgz",
@@ -4891,6 +4906,11 @@
         "arr-union": "^3.1.0",
         "extend-shallow": "^3.0.2"
       }
+    },
+    "pngjs": {
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/pngjs/-/pngjs-3.4.0.tgz",
+      "integrity": "sha512-NCrCHhWmnQklfH4MtJMRjZ2a8c80qXeMlQMv2uVp9ISJMTt562SbGd6n2oq0PaPgKm7Z6pL9E2UlLIhC+SHL3w=="
     },
     "posix-character-classes": {
       "version": "0.1.1",

--- a/package.json
+++ b/package.json
@@ -52,6 +52,8 @@
   },
   "dependencies": {
     "@types/base64-js": "^1.2.5",
-    "base64-js": "^1.3.0"
+    "@types/pixelmatch": "^4.0.0",
+    "base64-js": "^1.3.0",
+    "pixelmatch": "^4.0.2"
   }
 }


### PR DESCRIPTION
to eliminate failures due to small differences on non-Linux platforms

[pixelmatch](https://github.com/mapbox/pixelmatch) is a small and fast JavaScript pixel-level image comparison library, originally created to compare screenshots in tests.

This fixes the `psdReader` failures in #6.