### PR TITLE
Move `mkdir` to devDependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "ag-psd",
-  "version": "11.1.2",
+  "version": "11.1.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "gulp-spawn-mocha": "^6.0.0",
     "gulp-typescript": "^5.0.1",
     "merge2": "^1.4.1",
+    "mkdir": "0.0.2",
     "mocha": "^8.1.3",
     "remap-istanbul": "^0.13.0",
     "source-map-support": "^0.5.19",
@@ -53,7 +54,6 @@
   "dependencies": {
     "@types/base64-js": "^1.3.0",
     "base64-js": "^1.3.1",
-    "mkdir": "0.0.2",
     "parse-engine-data": "^0.1.2"
   }
 }


### PR DESCRIPTION
`mkdir` does not appear to be used anywhere except in tests for this package, and so can be moved to `devDependencies`. `mkdir` in general is a problematic dependency as it does not include any license information in its `package.json`. Our organization flags such dependencies and does not allow us to use them, which prevents us from consuming `ag-psd`. Moving `mkdir` to a devDependency allows us to circumvent this problem.