### PR TITLE
Set "sideEffects" value to "true" in package.json.

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "dist/index.js",
   "module": "dist-es/index.js",
   "browser": "dist/index.js",
-  "sideEffects": false,
+  "sideEffects": true,
   "repository": {
     "type": "git",
     "url": "https://github.com/Agamnentzar/ag-psd"


### PR DESCRIPTION
The `sideEffects` value for this package should be `true`. Its current value of `false` causes the `import "ag-psd/initialize-canvas"` declaration to be dropped by bundlers that support tree-shaking, like Webpack and esbuild. Having `sideEffects: false` here is incorrect because that `import` statement is explicitly used for its side-effects with this package. This doesn't affect browser environments that use bundling, as they don't use that import, but it does affect bundled Node environments, like AWS Lambda deployments, which do use that import.