### PR TITLE
Add support for cylinder warp

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@
 /test/read-write/ignore-*
 .vscode
 TODO
+.idea

--- a/src/additionalInfo.ts
+++ b/src/additionalInfo.ts
@@ -1008,6 +1008,10 @@ function parseWarp(warp: WarpDescriptor & QuiltWarpDescriptor): Warp {
 		vOrder: warp.vOrder,
 	};
 
+	if (warp.warpValues) {
+		result.cylinderValues = warp.warpValues;
+	}
+
 	if (warp.deformNumRows != null || warp.deformNumCols != null) {
 		result.deformNumRows = warp.deformNumRows;
 		result.deformNumCols = warp.deformNumCols;
@@ -1044,7 +1048,8 @@ function encodeWarp(warp: Warp): WarpDescriptor {
 	const bounds = warp.bounds;
 	const desc: WarpDescriptor = {
 		warpStyle: warpStyle.encode(warp.style),
-		warpValue: warp.value || 0,
+		warpValue: warp.value || undefined,
+		warpValues: warp.cylinderValues || undefined,
 		warpPerspective: warp.perspective || 0,
 		warpPerspectiveOther: warp.perspectiveOther || 0,
 		warpRotate: Ornt.encode(warp.rotate),

--- a/src/descriptor.ts
+++ b/src/descriptor.ts
@@ -793,7 +793,8 @@ export interface TextDescriptor {
 
 export interface WarpDescriptor {
 	warpStyle: string;
-	warpValue: number;
+	warpValue?: number;
+	warpValues?: number[]
 	warpPerspective: number;
 	warpPerspectiveOther: number;
 	warpRotate: string;
@@ -1645,6 +1646,7 @@ export const warpStyle = createEnum<WarpStyle>('warpStyle', 'none', {
 	inflate: 'warpInflate',
 	squeeze: 'warpSqueeze',
 	twist: 'warpTwist',
+	cylinder: 'warpCylinder',
 	custom: 'warpCustom',
 });
 

--- a/src/psd.ts
+++ b/src/psd.ts
@@ -243,7 +243,7 @@ export type Orientation = 'horizontal' | 'vertical';
 export type AntiAlias = 'none' | 'sharp' | 'crisp' | 'strong' | 'smooth' | 'platform' | 'platformLCD';
 export type WarpStyle =
 	'none' | 'arc' | 'arcLower' | 'arcUpper' | 'arch' | 'bulge' | 'shellLower' | 'shellUpper' | 'flag' |
-	'wave' | 'fish' | 'rise' | 'fisheye' | 'inflate' | 'squeeze' | 'twist' | 'custom';
+	'wave' | 'fish' | 'rise' | 'fisheye' | 'inflate' | 'squeeze' | 'twist' | 'custom' | 'cylinder';
 export type BevelStyle = 'outer bevel' | 'inner bevel' | 'emboss' | 'pillow emboss' | 'stroke emboss';
 export type BevelTechnique = 'smooth' | 'chisel hard' | 'chisel soft';
 export type BevelDirection = 'up' | 'down';
@@ -259,6 +259,7 @@ export type InterpolationMethod = 'classic' | 'perceptual' | 'linear';
 export interface Warp {
 	style?: WarpStyle;
 	value?: number;
+	cylinderValues?: number[];
 	perspective?: number;
 	perspectiveOther?: number;
 	rotate?: Orientation;


### PR DESCRIPTION
Photoshop introduced cylinder warp some while ago. This PR adds support for it.

The main difference here is that cylinder warp has "warpValues" which is an array of numbers, instead of a single warpValue. To play nice with Typescript, I'm assigning it as "cylinderValues" for the Warp interface so it is easier to differentiate it.

