### PR TITLE
fix section padding

### DIFF
--- a/src/psdWriter.ts
+++ b/src/psdWriter.ts
@@ -173,7 +173,7 @@ export function writeSection(writer: PsdWriter, round: number, func: () => void,
 	let length = writer.offset - offset - 4;
 	let len = length;
 
-	while ((writer.offset % round) !== 0) {
+	while ((writer.offset - offset) % round !== 0) {
 		writeUint8(writer, 0);
 		len++;
 	}


### PR DESCRIPTION
Handle padding based on a section length and not on the entire writer offset.