### PR TITLE
fix: byte-swap 16-bit channel data from big-endian to native endian

### DIFF
--- a/src/psdReader.ts
+++ b/src/psdReader.ts
@@ -982,6 +982,13 @@ function bytesToArray(bytes: Uint8Array, bitDepth: number) {
 	if (bitDepth === 8) {
 		return bytes;
 	} else if (bitDepth === 16) {
+		// PSD files store 16-bit channel data in big-endian byte order.
+		// Swap each pair of bytes so that Uint16Array (native-endian) reads the correct values.
+		for (let i = 0; i < bytes.byteLength; i += 2) {
+			const tmp = bytes[i];
+			bytes[i] = bytes[i + 1];
+			bytes[i + 1] = tmp;
+		}
 		if (bytes.byteOffset % 2) {
 			const result = new Uint16Array(bytes.byteLength / 2);
 			new Uint8Array(result.buffer, result.byteOffset, result.byteLength).set(bytes);


### PR DESCRIPTION
## Problem

  16-bit PSD files render with glitched/noisy pixels on little-endian machines (x86, ARM).

  PSD files store 16-bit channel values in big-endian byte order, but `bytesToArray` creates a `Uint16Array` view directly over the raw bytes without byte-swapping. On little-endian machines, every non-symmetric value gets its high and low bytes
   reversed, producing corrupted pixel data.

  ### Why the existing test didn't catch this

  The `test/read/16bits` fixture uses an orange background + gray circle whose byte pairs happen to be nearly adjacent values:

  G channel raw bytes: [0x6F, 0x70]
    → big-endian (correct): 0x6F70 >> 8 = 111
    → little-endian (buggy): 0x706F >> 8 = 112

  The swap only produces ±1 difference for this particular image, making the bug invisible. With real-world images containing diverse colors, the corruption is severe:

  R channel raw bytes: [0x53, 0xEA]
    → big-endian (correct): 0x53EA >> 8 = 83
    → little-endian (buggy): 0xEA53 >> 8 = 234

  ### Before / After (Photoshop-exported RGB 16-bit PSD)
  (test with my psd file)

  | Before (buggy) | After (fixed) |
  |---|---|
  | <img width="460" height="437" alt="wrong" src="https://github.com/user-attachments/assets/5ef21c4e-12a2-438b-b13f-413cca2c9453" /> | <img width="460" height="438" alt="fixed-composite" src="https://github.com/user-attachments/assets/fbdee58a-5259-4a95-9fa9-df0d3559d5ae" /> |

  ## Fix

  Add a 2-byte swap loop in `bytesToArray` for the `bitDepth === 16` path, before constructing the `Uint16Array`.

  The 32-bit path already handles its own endian swap in `readDataRaw`, but for 16-bit the swap was missing entirely. The fix is placed in `bytesToArray` rather than `readDataRaw` because both the raw and zip decompression code paths call
  `bytesToArray`, so a single fix covers all 16-bit reads.

  > **Note:** The swap is unconditional (no runtime endian check), consistent with the existing 32-bit swap in `readDataRaw` which also swaps unconditionally. The codebase assumes little-endian throughout, which covers all practical JS/Node.js
  environments today (x86, ARM, Apple Silicon).

  ## Verification

  - All 184 existing tests pass
  - The single `16bits` snapshot diff is ±1 per channel (e.g. `G: 112→111`) — the snapshot was generated under the buggy byte order and needs to be regenerated
  - 8-bit files are unaffected (`bytesToArray` returns raw bytes as-is for `bitDepth === 8`)