### PR TITLE
feat: read and write document-level pattern (Patt) blocks

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Implemented according to [official documentation](https://www.adobe.com/devnet-a
 * Does not support The Large Document Format (8BPB/PSB) 
 * Does not support color palettes
 * Does not support animations
-* Does not support patterns (or "Pattern Overlay" layer effect)
+* Limited pattern support: reads and writes document-level pattern blocks (`Patt`/`Pat2`/`Pat3`) for raw/RLE-compressed, RGB/Grayscale patterns. Does not support zip-compressed patterns (used by most real Photoshop files), Indexed or 16-bit patterns, or the "Pattern Overlay" layer effect (only its name/id reference is read/written)
 * Does not support some metadata fields
 * Does not support 3d effects
 * Does not support some new features from latest versions of Photoshop

--- a/README_PSD.md
+++ b/README_PSD.md
@@ -365,7 +365,7 @@ Example layer structure:
 
   _TODO_
 
-- `patterns` _not supported yet_
+- `patterns` Document-level pattern resources (`Patt`/`Pat2`/`Pat3` blocks). Each entry is a `PatternInfo` with RGBA pixel `data` and `bounds`. Reading and writing support raw and RLE compression in RGB/Grayscale color modes; zip-compressed, Indexed and 16-bit patterns are not supported. Layer-effect pattern references (Pattern Overlay, stroke/vector fill) still only carry a `name`/`id` and are not linked to these resources.
 
 - `vectorFill` Fill color, gradient or pattern for the vector mask. Use `type` field to distinguish between different vector fill types, like this:
 

--- a/src/additionalInfo.ts
+++ b/src/additionalInfo.ts
@@ -3,7 +3,7 @@ import { readEffects, writeEffects } from './effectsHelpers';
 import { clamp, createEnum, layerColors, MOCK_HANDLERS } from './helpers';
 import { LayerAdditionalInfo, BezierPath, Psd, BrightnessAdjustment, ExposureAdjustment, VibranceAdjustment, ColorBalanceAdjustment, BlackAndWhiteAdjustment, PhotoFilterAdjustment, ChannelMixerChannel, ChannelMixerAdjustment, PosterizeAdjustment, ThresholdAdjustment, GradientMapAdjustment, CMYK, SelectiveColorAdjustment, ColorLookupAdjustment, LevelsAdjustmentChannel, LevelsAdjustment, CurvesAdjustment, CurvesAdjustmentChannel, HueSaturationAdjustment, HueSaturationAdjustmentChannel, PresetInfo, Color, ColorBalanceValues, WriteOptions, LinkedFile, PlacedLayerType, Warp, KeyDescriptorItem, BooleanOperation, LayerEffectsInfo, Annotation, LayerVectorMask, AnimationFrame, Timeline, PlacedLayerFilter, UnitsValue, Filter, PlacedLayer, ReadOptions, Layer } from './psd';
 import { PsdReader, readSignature, readUnicodeString, skipBytes, readUint32, readUint8, readFloat64, readUint16, readBytes, readInt16, checkSignature, readFloat32, readFixedPointPath32, readSection, readColor, readInt32, readPascalString, readUnicodeStringWithLength, readAsciiString, readPattern, readLayerInfo } from './psdReader';
-import { PsdWriter, writeZeros, writeSignature, writeBytes, writeUint32, writeUint16, writeFloat64, writeUint8, writeInt16, writeFloat32, writeFixedPointPath32, writeUnicodeString, writeSection, writeUnicodeStringWithPadding, writeColor, writePascalString, writeInt32 } from './psdWriter';
+import { PsdWriter, writeZeros, writeSignature, writeBytes, writeUint32, writeUint16, writeFloat64, writeUint8, writeInt16, writeFloat32, writeFixedPointPath32, writeUnicodeString, writeSection, writeUnicodeStringWithPadding, writeColor, writePascalString, writeInt32, writePattern } from './psdWriter';
 import { Annt, BlnM, DescriptorColor, DescriptorUnitsValue, parsePercent, parseUnits, parseUnitsOrNumber, QuiltWarpDescriptor, strokeStyleLineAlignment, strokeStyleLineCapType, strokeStyleLineJoinType, TextDescriptor, textGridding, unitsPercent, unitsValue, WarpDescriptor, warpStyle, writeVersionAndDescriptor, readVersionAndDescriptor, StrokeDescriptor, Ornt, horzVrtcToXY, LmfxDescriptor, Lfx2Descriptor, FrameListDescriptor, TimelineDescriptor, FrameDescriptor, xyToHorzVrtc, serializeEffects, parseEffects, parseColor, serializeColor, serializeVectorContent, parseVectorContent, parseTrackList, serializeTrackList, FractionDescriptor, BlrM, BlrQ, SmBQ, SmBM, DspM, UndA, Cnvr, RplS, SphM, Wvtp, ZZTy, Dstr, Chnl, MztT, Lns, blurType, DfsM, ExtT, ExtR, FlCl, CntE, WndM, Drct, IntE, IntC, FlMd, unitsPercentF, frac, ClrS, descBoundsToBounds, boundsToDescBounds, presetKindType, gradientInterpolationMethodType, PxScDescriptor } from './descriptor';
 import { serializeEngineData, parseEngineData } from './engineData';
 import { encodeEngineData, decodeEngineData } from './text';
@@ -3679,21 +3679,25 @@ if (MOCK_HANDLERS) {
 } else {
 	addHandler(
 		'Patt', // TODO: handle also Pat2 & Pat3
-		target => !target,
+		target => !!(target.patterns && target.patterns.length > 0),
 		(reader, target, left) => {
-			if (!left()) return;
-
-			skipBytes(reader, left()); return; // not supported yet
-			target; readPattern;
-
-			// if (!target.patterns) target.patterns = [];
-			// target.patterns.push(readPattern(reader));
-			// skipBytes(reader, left());
+			while (left() > 0) {
+				const pattern = readPattern(reader);
+				if (target.patterns === undefined) target.patterns = [];
+				target.patterns.push(pattern);
+			}
 		},
-		(_writer, _target) => {
+		(writer, target, _, _options) => {
+			const patterns = target.patterns || [];
+			for (const pattern of patterns) {
+				writePattern(writer, pattern);
+			}
 		},
 	);
 }
+
+addHandlerAlias('Pat2', 'Patt');
+addHandlerAlias('Pat3', 'Patt');
 
 /*
 interface CAIDesc {

--- a/src/psdWriter.ts
+++ b/src/psdWriter.ts
@@ -1,4 +1,4 @@
-import { Psd, Layer, LayerAdditionalInfo, ColorMode, SectionDividerType, WriteOptions, Color, GlobalLayerMaskInfo, PixelData, LayerMaskData, Compression, ChannelID } from './psd';
+import { Psd, Layer, LayerAdditionalInfo, ColorMode, SectionDividerType, WriteOptions, Color, GlobalLayerMaskInfo, PixelData, LayerMaskData, Compression, ChannelID, PatternInfo } from './psd';
 import { hasAlpha, createCanvas, writeDataRLE, LayerChannelData, ChannelData, offsetForChannel, createImageData, fromBlendMode, clamp, LayerMaskFlags, MaskParams, ColorSpace, Bounds, largeAdditionalInfoKeys, RAW_IMAGE_DATA, writeDataZipWithoutPrediction, imageDataToCanvas } from './helpers';
 import { ExtendedWriteOptions, infoHandlers } from './additionalInfo';
 import { InternalImageResources, resourceHandlers } from './imageResources';
@@ -834,4 +834,79 @@ export function writeColor(writer: PsdWriter, color: Color | undefined) {
 		writeUint16(writer, Math.round(color.k * 10000 / 255));
 		writeZeros(writer, 6);
 	}
+}
+
+// ponytail: only round-trips RGB 8-bit patterns; source colorMode (16-bit/Indexed) is not preserved,
+// since readPattern already converted everything to RGBA. Upgrade if pattern colorMode must survive write.
+export function writePattern(writer: PsdWriter, pattern: PatternInfo) {
+	const width = pattern.bounds.w;
+	const height = pattern.bounds.h;
+	const pixelData: PixelData = { width, height, data: pattern.data };
+
+	writeUint32(writer, 0); // length, fixed up below
+	const pattsOffset = writer.offset;
+
+	writeUint32(writer, 1); // version
+	writeUint32(writer, ColorMode.RGB); // color mode - rgb only
+
+	writeInt16(writer, pattern.x);
+	writeInt16(writer, pattern.y);
+
+	writeUnicodeString(writer, pattern.name + '\0'); // name
+	writePascalString(writer, pattern.id, 1); // id
+
+	// virtual memory array list
+	writeUint32(writer, 3); // version
+	writeUint32(writer, 0); // length, fixed up below
+	const vlOffset = writer.offset;
+
+	const top = pattern.bounds.y;
+	const left = pattern.bounds.x;
+	const bottom = top + height;
+	const right = left + width;
+
+	writeUint32(writer, top);
+	writeUint32(writer, left);
+	writeUint32(writer, bottom);
+	writeUint32(writer, right);
+
+	writeUint32(writer, 24); // channels count
+
+	// channels: RGB at indices 0,1,2 and alpha at index 25
+	for (let i = 0; i < 24 + 2; i++) {
+		const offset = i < 3 ? i : (i === 25 ? 3 : -1);
+
+		if (offset < 0) {
+			writeUint32(writer, 0); // has
+			continue;
+		}
+
+		// worst-case RLE size for a single channel: width + 1 per scanline, plus scanline length headers
+		const buffer = new Uint8Array(width * height + 2 * height + 2 * width + 16);
+		// ponytail: pattern channels always use small (2-byte) RLE scanline headers, matching
+		// readPattern which reads them as non-large; `large` here only affects the header width.
+		const data = writeDataRLE(buffer, pixelData, [offset], false)!;
+
+		writeUint32(writer, 1); // has
+		writeUint32(writer, data.length + 4 + 16 + 2 + 1); // length
+		writeUint32(writer, 8); // pixelDepth
+		writeUint32(writer, top);
+		writeUint32(writer, left);
+		writeUint32(writer, bottom);
+		writeUint32(writer, right);
+		writeUint16(writer, 8); // pixelDepth2
+		writeUint8(writer, 1); // compressionMode - rle
+		writeBytes(writer, data);
+	}
+
+	const vlLength = writer.offset - vlOffset;
+	let pattsLength = writer.offset - pattsOffset;
+
+	while (pattsLength % 4) {
+		writeZeros(writer, 1);
+		pattsLength++;
+	}
+
+	writer.view.setUint32(vlOffset - 4, vlLength, false);
+	writer.view.setUint32(pattsOffset - 4, pattsLength, false);
 }

--- a/src/test/psdWriter.spec.ts
+++ b/src/test/psdWriter.spec.ts
@@ -2,9 +2,9 @@ import * as fs from 'fs';
 import * as path from 'path';
 import { expect } from 'chai';
 import { loadCanvasFromFile, compareBuffers, createCanvas, compareCanvases } from './common';
-import { Psd, WriteOptions, ReadOptions, } from '../psd';
-import { writePsd, writeSignature, getWriterBuffer, createWriter } from '../psdWriter';
-import { readPsd, createReader } from '../psdReader';
+import { Psd, WriteOptions, ReadOptions, PatternInfo } from '../psd';
+import { writePsd, writeSignature, getWriterBuffer, createWriter, writePattern } from '../psdWriter';
+import { readPsd, createReader, readPattern } from '../psdReader';
 import { writePsdBuffer, readPsd as readPsdBuffer } from '../index';
 
 const layerImagesPath = path.join(__dirname, '..', '..', 'test', 'layer-images');
@@ -96,6 +96,30 @@ describe('PsdWriter', () => {
 		};
 
 		expect(() => writePsd(writer, psd)).throw(`Invalid document size`);
+	});
+
+	it('round-trips a pattern through writePattern/readPattern', () => {
+		const w = 5, h = 3;
+		const data = new Uint8Array(w * h * 4);
+		for (let i = 0; i < w * h; i++) {
+			data[i * 4 + 0] = i * 10;
+			data[i * 4 + 1] = i * 5;
+			data[i * 4 + 2] = i * 2;
+			data[i * 4 + 3] = 255;
+		}
+		const pattern: PatternInfo = { id: 'abc123', name: 'mypat', x: 1, y: 2, bounds: { x: 0, y: 0, w, h }, data };
+
+		const writer = createWriter();
+		writePattern(writer, pattern);
+		const buffer = getWriterBuffer(writer);
+		const result = readPattern(createReader(buffer));
+
+		expect(result.id).equal(pattern.id);
+		expect(result.name).equal(pattern.name);
+		expect(result.x).equal(pattern.x);
+		expect(result.y).equal(pattern.y);
+		expect(result.bounds).eql(pattern.bounds);
+		expect(Array.from(result.data)).eql(Array.from(data));
 	});
 
 	const fullImage = loadCanvasFromFile(path.join(layerImagesPath, 'full.png'));


### PR DESCRIPTION
## Summary

Wire the existing `readPattern` decoder into the PSD additional-info flow and add a matching writer, so document-level pattern resources (`Patt`/`Pat2`/`Pat3` blocks) now round-trip instead of being skipped. Scope is intentionally narrow: raw/RLE compression, RGB/Grayscale only.

2 commits · 5 files · no public API change (adds `Psd.patterns` population + `writePattern`).

## Key changes

### `src/additionalInfo.ts` — connect the `Patt` handler

- Read patterns into `Psd.patterns` (looped over the block) instead of `skipBytes`.
- Alias `Pat2`/`Pat3` to the same handler.
- Add a write handler that serializes each pattern.

### `src/psdWriter.ts` — add `writePattern`

- Mirror of `readPattern`: pattern header, VMAL, per-channel RLE, with length/alignment fixups.
- Pattern channels use small (2-byte) RLE scanline headers to match the reader (PSB-safe).
- RGB 8-bit only; source colorMode (16-bit/Indexed) is not preserved (noted in code).

### `src/test/psdWriter.spec.ts` — round-trip test

- `writePattern` -> `readPattern`, asserting metadata, bounds, and full pixel data.

### Docs

- `README.md` / `README_PSD.md` updated to describe partial pattern support and the remaining gaps.

## Type

- [x] feat · [x] docs · [x] test

## Breaking changes

None.

## Not covered (follow-ups)

- Zip (deflate) compressed patterns — used by most real Photoshop files; current support is raw/RLE only.
- Indexed and 16-bit pattern pixel decoding.
- Linking `EffectPattern` (Pattern Overlay / stroke / vector fill) references to decoded pattern resources.

## Validation

- `tsc --project tsconfig.json` — compiles clean.
- `mocha dist/test/psdWriter.spec.js dist/test/psdReader.spec.js` — 140 passing, 13 pending (pattern-zip / cmyk skips unchanged).